### PR TITLE
Rename dist workflow

### DIFF
--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -1,4 +1,4 @@
-name: Check dist directory
+name: Check dist
 
 on:
   push:
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  dist-check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Make this action required for a PR to merge but currently it has a bad name